### PR TITLE
Update typo in code for language array

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -30,8 +30,8 @@ This option specifies the available language options. This can be any of the fol
 
 ```json
 "languages": [
-  [{"id": "en", "title": "English"}],
-  [{"id": "fr", "title": "French"}],
+  {"id": "en", "title": "English"},
+  {"id": "fr", "title": "French"},
 ]
 ```
 


### PR DESCRIPTION
Sanity breaks when using example with array of arrays. Correct seems to be array of object.s