### PR TITLE
📝 update docs on usage with custom actions

### DIFF
--- a/docs/usage-with-custom-publish.md
+++ b/docs/usage-with-custom-publish.md
@@ -48,3 +48,27 @@ export default function resolveDocumentActions(props) {
   ]
 }
 ```
+
+If you do not have a custom publish action defined and want to use the publish action from this plugin, you should replace the default publish action from Sanity core with the imported `PublishWithi18nAction` from this plugin. Doing so will replace the default publish action on the "publish" button in the Sanity studio.
+
+Example:
+
+```js
+import {
+  PublishWithi18nAction,
+  DeleteWithi18nAction,
+  DuplicateWithi18nAction,
+} from '@sanity/document-internationalization/lib/actions'
+import defaultResolve, { PublishAction } from 'part:@sanity/base/document-actions'
+
+// @README https://www.sanity.io/docs/document-actions
+export default function resolveDocumentActions(props) {
+  return [
+    ...defaultResolve(props).map((Action) =>
+      Action === PublishAction ? PublishWithi18nAction : Action,
+    ),
+    DeleteWithi18nAction,
+    DuplicateWithi18nAction,
+  ]
+}
+```


### PR DESCRIPTION
Adds section about replacing the default publish action with the i18n publish action, as returning it alongside the default actions from `defaultResolve` does not replace the functionality of publish button in the studio.