### PR TITLE
Added Shqip Flag Code.

### DIFF
--- a/src/utils/getFlag.ts
+++ b/src/utils/getFlag.ts
@@ -27,6 +27,8 @@ export const getFlagCode = (code = ``): string => {
   switch (code.toLocaleLowerCase()) {
     case `en`:
       return `gb`
+    case `sq`:
+      return `al`
 
     default:
       return code


### PR DESCRIPTION
Added support for `sq` without `sq_AL` to display the Albanian flag. If `sq_AL` is used, the regex under the hood extracts the `al` code and correctly displays the flag of Albania, but with just `sq` it shows nothing.

The reason is because `sq` doesn't match the code of country Albania `al` which uses that language, as defined on emoji list.
The only case I found was with `en` which didn't had a flag of England but Great Britain, so the switch was used to change the code to `gb`.

Solution will be to add `sq` to switch to use the flag code of `al` (Albania).