### PR TITLE
Add eslint directives to pass linting

### DIFF
--- a/migrations/createMetadata.ts
+++ b/migrations/createMetadata.ts
@@ -28,6 +28,7 @@ const client = sanityClient({
   projectId: '6h1mv88x',
   dataset: 'production-v3',
   apiVersion: `2022-06-01`,
+  // eslint-disable-next-line no-process-env
   token: process.env.SANITY_TOKEN,
 })
 
@@ -103,11 +104,13 @@ const migrateNextBatch = async () => {
   const patches = buildPatches(documents)
 
   if (patches.length === 0) {
-    console.log('No more documents to create or patch!')
+    // eslint-disable-next-line no-console
+    console.debug('No more documents to create or patch!')
     return null
   }
 
-  console.log(
+  // eslint-disable-next-line no-console
+  console.debug(
     `Checking batch:\n %s`,
     patches.map((patch) => `${patch.id} => ${JSON.stringify(patch.patch)}`).join('\n')
   )
@@ -119,5 +122,6 @@ const migrateNextBatch = async () => {
 
 migrateNextBatch().catch((err) => {
   console.error(err)
+  // eslint-disable-next-line no-process-exit
   process.exit(1)
 })

--- a/migrations/renameField.ts
+++ b/migrations/renameField.ts
@@ -5,6 +5,7 @@ const client = sanityClient({
   projectId: '6h1mv88x',
   dataset: 'production-v3',
   apiVersion: `2022-06-01`,
+  // eslint-disable-next-line no-process-env
   token: process.env.SANITY_TOKEN,
 })
 
@@ -44,10 +45,12 @@ const migrateNextBatch = async () => {
   const documents = await fetchDocuments()
   const patches = buildPatches(documents)
   if (patches.length === 0) {
-    console.log('No more documents to migrate!')
+    // eslint-disable-next-line no-console
+    console.debug('No more documents to migrate!')
     return null
   }
-  console.log(
+  // eslint-disable-next-line no-console
+  console.debug(
     `Migrating batch:\n %s`,
     patches.map((patch) => `${patch.id} => ${JSON.stringify(patch.patch)}`).join('\n')
   )
@@ -58,5 +61,6 @@ const migrateNextBatch = async () => {
 
 migrateNextBatch().catch((err) => {
   console.error(err)
+  // eslint-disable-next-line no-process-exit
   process.exit(1)
 })

--- a/src/schema/translation/metadata.ts
+++ b/src/schema/translation/metadata.ts
@@ -3,6 +3,9 @@ import {TranslateIcon} from '@sanity/icons'
 
 import {METADATA_SCHEMA_NAME} from '../../constants'
 
+// eslint-disable-next-line no-warning-comments
+// FIXME: TS having a hard time determining the return type here. Likely a V3 type problem.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default (schemaTypes: string[]) =>
   defineType({
     type: 'document',


### PR DESCRIPTION
The defineType return type problem in `metadata.ts` is interesting. Something Studio will fix in v3 type definitions?