### PR TITLE
Fix deps and Preview import to work on rc3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sanity/icons": "^1.3.6",
         "@sanity/incompatible-plugin": "^1.0.4",
-        "@sanity/ui": "1.0.0-beta.32",
+        "@sanity/ui": "^1.0.0",
         "@sanity/uuid": "^3.0.1",
         "sanity-plugin-internationalized-array": "^1.4.1",
         "sanity-plugin-utils": "^1.0.0"
@@ -36,7 +36,7 @@
         "prettier-plugin-packagejson": "^2.3.0",
         "react": "^18",
         "rimraf": "^3.0.2",
-        "sanity": "3.0.0-rc.2",
+        "sanity": "^3.0.0",
         "typescript": "^4.9.3"
       },
       "engines": {
@@ -44,7 +44,7 @@
       },
       "peerDependencies": {
         "react": "^18",
-        "sanity": "dev-preview || 3.0.0-rc.2"
+        "sanity": "^3.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3184,9 +3184,9 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0-rc.2.tgz",
-      "integrity": "sha512-JWC4LuN1q51+KM+YlpML3nEK0ElVTvfLrfbVjBUtPhTPaaOydKBacImEusfCMHLmDc2TP0Ua44/qUiYYWZ07UA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0.tgz",
+      "integrity": "sha512-c+QcM42zOqIcuwZOPQJRKAw4f0JBWmwo5B+r8U01WbDQ/nrDz35i/xMa4N2qVuwtV+Cclv6WYa9XbfGQP/8Mig==",
       "dev": true,
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
@@ -3194,9 +3194,9 @@
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.0.0-rc.2.tgz",
-      "integrity": "sha512-umWFPQu7j7a2OuROyvAVy1El2hsVg33UbmUnmhzxsobFE38mMPXf4HhRliyvA/fIeeNalOBO+MWJpGxo7dZf3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.0.0.tgz",
+      "integrity": "sha512-YEFZYQvA9DhHcCR5YHMy7mCpb31i0Zyo2umhp8RIKjWSD7hYYh2HZh0traW4GdKWVQ4GYXUoOd1m8OkGOFaeHw==",
       "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.19.0",
@@ -3410,10 +3410,15 @@
       "integrity": "sha512-HtPs1RbULM/z8wt3BbeeZlxVNiJbl+zQAwwrbc0KAq5NHaCG3MmffOVCpRhNTs+TK67MdN6aZ+5wzPtRZvME+w==",
       "dev": true
     },
+    "node_modules/@sanity/color": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.20.tgz",
+      "integrity": "sha512-dHPgiCMf+lwvQls5uPzorfiq9YuU41AzvifA+ugVHmXvq7JBoofoOPUOmdHUQF0l0shSy0nD3zn52j2I+T2ekg=="
+    },
     "node_modules/@sanity/diff": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.0.0-rc.2.tgz",
-      "integrity": "sha512-etgoHJQYK5X6TDoQXEO4FjVdc8qUuhTyjbnYNkqEb/MC7Dwc3Dy7JFm8IRwiB/qfGASxH6d7NnFlV0+wCccveQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.0.0.tgz",
+      "integrity": "sha512-tE1lL963nR1fJmy6uHnyVVCDym+CeZe/H8q0I2YpeCIoR7rA25tXQxD4NsBwKtO1d1eY2zBofXqq4JUakNBjuQ==",
       "dev": true,
       "dependencies": {
         "diff-match-patch": "^1.0.4"
@@ -3433,9 +3438,9 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.0.0-rc.2.tgz",
-      "integrity": "sha512-iqIDQHsgeAV3Nkue6Y1XJ5rxwQQR02AEUeCrLq+167wg4KmSogfoqj+E6PVp5eDrvKmwziVKGkWwFT/97PB5Zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.0.0.tgz",
+      "integrity": "sha512-iemJZ9xdW8dliptNg+X2/04EX0vfW4l3VzEWDb6ZvKF+GhpJ2/QwAiI398wCYmDHzEicugFoK29HQVtFk07EYA==",
       "dev": true,
       "dependencies": {
         "archiver": "^5.0.0",
@@ -3576,14 +3581,14 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.0.0-rc.2.tgz",
-      "integrity": "sha512-6eB/eG1QXsw3CyK78rsKcqDTj2jipoyhxckDWbM1gAk4dutNQENCgCAkWOtuGda5vKcU8KeVooUVHopTlbFYJA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.0.0.tgz",
+      "integrity": "sha512-n+3wJa1Uu13FPsmf29sQ1L3D64BuiMKboN3ZZwp1e0u/k6ALb9NUeIiqqttk8nW+TUz8dnkRngJMUPIsj4pltg==",
       "dev": true,
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.0.0-rc.2",
+        "@sanity/mutator": "3.0.0",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -3747,19 +3752,22 @@
       }
     },
     "node_modules/@sanity/logos": {
-      "version": "1.1.20-beta.3",
-      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-1.1.20-beta.3.tgz",
-      "integrity": "sha512-aMxqGIemeO12BxbpWD+5dQeTK2maYRsLa4f5cdr+ah9uyfooNTmpz9vQlSaukyUIKG+Skzx+aMzj1qWjzB2pig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-2.0.2.tgz",
+      "integrity": "sha512-BsBNt4ldWNAuKeHge4nKHnN43BN8BwLJuf+HDhrg/ngnORUjty5WV4KVoQkQ2FSTv5YtpJjSuNGSXwT+Araegw==",
       "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      },
       "peerDependencies": {
         "@sanity/color": "^2.0",
         "react": "^18"
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.0.0-rc.2.tgz",
-      "integrity": "sha512-bmX8lE+gxz/ws2D6cewqWprJFHQX46kFKvdIx5cqYZElIp9GDrY9ICk5exSfQgiTA4FW1AiHIY6EGVM8kqbNwQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.0.0.tgz",
+      "integrity": "sha512-U0Jm5BE4WSMnuy8dPOApLiFpaJ5B+L1wXRQ1558iPXc2r1cX2ISWBQTcJHRNQO1Gd1SUWGjDwNs6YbUxH4cGpA==",
       "dev": true,
       "dependencies": {
         "@sanity/uuid": "^3.0.1",
@@ -4281,16 +4289,16 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.0.0-rc.2.tgz",
-      "integrity": "sha512-hpu/rQuKwWTYPU5V4vKmrDZQzuhM+IuBC3W5M3l5Mmijqx+xll2fKqX9uKdR1a+kuuDgu/n74nLBHVzOI5vF0g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.0.0.tgz",
+      "integrity": "sha512-72x1d1ojV7ioOF1pmPolc6By2XxdZI7vJV0XvtD8RbBsitBWdTuvXteSnumLVP8qm/JO11WBA75BdgofdtpkEA==",
       "dev": true,
       "dependencies": {
-        "@sanity/block-tools": "3.0.0-rc.2",
-        "@sanity/schema": "3.0.0-rc.2",
+        "@sanity/block-tools": "3.0.0",
+        "@sanity/schema": "3.0.0",
         "@sanity/slate-react": "2.30.1",
-        "@sanity/types": "3.0.0-rc.2",
-        "@sanity/util": "3.0.0-rc.2",
+        "@sanity/types": "3.0.0",
+        "@sanity/util": "3.0.0",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -4315,13 +4323,13 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.0.0-rc.2.tgz",
-      "integrity": "sha512-cBgSmx4EY3WizUn9zjueu1HXu1b/FgeQmvjPltXBwmzjHTvlBBlyyg/pIO9qpLFMEU9lO3H1+JExlNL6boRCGw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.0.0.tgz",
+      "integrity": "sha512-SPnlbA4Vx/RjtPdLSmGml6jB9Pw4zbKNfNJfTq97vVn7lFh93wpsQ4NNMzUPKTLYvEIfPLq/Bz1YpANoSpGT1w==",
       "dev": true,
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.0.0-rc.2",
+        "@sanity/types": "3.0.0",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -4347,9 +4355,9 @@
       }
     },
     "node_modules/@sanity/server": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/server/-/server-3.0.0-rc.2.tgz",
-      "integrity": "sha512-mD50vHzDSk4N/jxpTspQPGGmpYxJHANqSstorJnHGbRSOXGVS5/wSCJ26bU/1jXzZini73uRTQrNenN/577cpQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/server/-/server-3.0.0.tgz",
+      "integrity": "sha512-F4CCt6MBmf+F368mSrUtmnr+JMYxY3Egr70/NFlDiAVq1uCx/XojadyikFSJnT7yMjdq5vTCIR28kQlykJAtdQ==",
       "dev": true,
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
@@ -4423,25 +4431,29 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-rc.2.tgz",
-      "integrity": "sha512-0zZPU3lrTblkVbaPQs/xQohxT3sSdcfDdU3TRh1Ip78MGU/l9YMMCbHTrbaP0J//FTicYR5AaKxeG4UW/4xrfw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-I+M3sdwxjZLR0BcbMubvSPSxc84hm0Pu3L5go87RwGCRKnGF0eU3KclxByloIE6XdLs9f8sGaXC4D9UUdKVWMA==",
       "dev": true,
       "dependencies": {
         "@sanity/client": "^3.4.1",
-        "@types/react": "^18.0.21"
+        "@types/react": "^18.0.25"
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "1.0.0-beta.32",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.0.0-beta.32.tgz",
-      "integrity": "sha512-mzJXwdevJr/LAPnXHFnkhs4fXEuS7uDQqnvPRdX9t76GG9diyW5TOBemsujuFk4qFRKRUzgFDM3CyqllWbL2zw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.0.0.tgz",
+      "integrity": "sha512-Ru0ZaKValcOsSj3yaC1G+oBn+t4egtSMnrw22cg3fpuDvWN7Oj4cZVaTUBmggUDSeP8+wsSO3crZ87aHC9H1Hw==",
       "dependencies": {
         "@floating-ui/react-dom": "^1.0.0",
-        "@sanity/color": "2.1.19-beta.3",
-        "@sanity/icons": "1.3.9-beta.3",
+        "@sanity/color": "^2.1.20",
+        "@sanity/icons": "^2.0.0",
+        "csstype": "^3.1.1",
         "framer-motion": "^7.5.3",
         "react-refractor": "^2.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": "^18",
@@ -4450,15 +4462,13 @@
         "styled-components": "^5.2"
       }
     },
-    "node_modules/@sanity/ui/node_modules/@sanity/color": {
-      "version": "2.1.19-beta.3",
-      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.19-beta.3.tgz",
-      "integrity": "sha512-421F+o3BbumkPzj93wsM9VXeX4wuhrXp/B/AHVuB0uXWLEGYnrY2mBzRU44fsZGQWW4fgy139B5eV5orFzYJkA=="
-    },
     "node_modules/@sanity/ui/node_modules/@sanity/icons": {
-      "version": "1.3.9-beta.3",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.9-beta.3.tgz",
-      "integrity": "sha512-IHacaR96czI6402cBlkiKqmi7AASj3jLVYZ8dTD9caRGi0Dp7eJzI9RFp0ptJNxQYdYbZCZu0D/oEdhJfHEMGA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.0.0.tgz",
+      "integrity": "sha512-TLrJ9YXUzZeb1gijjCkERaie1LipSYfC/7KKIzJxGxPfxq+90HRklo/zzVFk45GctXFhxJRgMA5sbkCDVb9RiA==",
+      "engines": {
+        "node": ">=14.0.0"
+      },
       "peerDependencies": {
         "react": "^18"
       }
@@ -4512,12 +4522,12 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.0.0-rc.2.tgz",
-      "integrity": "sha512-3JmfSKVyb+Y/rv1zvFjr+mG9yWGNGiqNtycvPRITf2LLKiooqZfxD9xX6ZTDZgI4+IyXgTimqgbbZAAsNrE1jw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-UqE1E9KPwq8Ym3wcD8SXGSuXp5HlZMsNxsE0wD3eecPEOD9Z1gYU2p7AaTO81+gp4fOWCQbWdsZWrNi6XQF3rA==",
       "dev": true,
       "dependencies": {
-        "@sanity/types": "3.0.0-rc.2",
+        "@sanity/types": "3.0.0",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
@@ -4535,12 +4545,12 @@
       }
     },
     "node_modules/@sanity/validation": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.0.0-rc.2.tgz",
-      "integrity": "sha512-v0JPfK9t8HJ7XriYyQbJItI9Jfrf5BVAGjRwTrAVKTrCyghNzjNJSok7yNR9EDIYDNxrKh+EGrW2JQkfEPlSgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.0.0.tgz",
+      "integrity": "sha512-Qj2qnJ+MsnVohURsNuYmAYNW+oh60NJUZlVPTx2oUdkJtzDYmMc2dIy9R1BjItI3V1QxNFU/tUcvqAPiGvULCg==",
       "dev": true,
       "dependencies": {
-        "@sanity/types": "3.0.0-rc.2",
+        "@sanity/types": "3.0.0",
         "date-fns": "^2.26.1",
         "lodash": "^4.17.21",
         "rxjs": "^6.5.3"
@@ -4980,9 +4990,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.189",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
-      "integrity": "sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==",
+      "version": "4.14.190",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.190.tgz",
+      "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -6938,8 +6948,7 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -16328,9 +16337,9 @@
       "dev": true
     },
     "node_modules/sanity": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.0.0-rc.2.tgz",
-      "integrity": "sha512-ZT4ZTsoFCGlpAFz6h4hYBRNwXCDKub3WxRa6B3nx87nS7DvwNB5w/b3FJfjwfGD2EZzgZJsfw1EEqySxuelS5A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.0.0.tgz",
+      "integrity": "sha512-90Y143rQntPYVYo9l8N6sf6GUQFAxagIvJ95k4/Xwz/ATpEEVVVFLAMwKj0IF461sjnyBzmEvX7kYngP7AINlQ==",
       "dev": true,
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
@@ -16340,27 +16349,27 @@
         "@rexxars/react-sortable-hoc": "^2.0.0",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.0",
-        "@sanity/block-tools": "3.0.0-rc.2",
-        "@sanity/cli": "3.0.0-rc.2",
+        "@sanity/block-tools": "3.0.0",
+        "@sanity/cli": "3.0.0",
         "@sanity/client": "^3.4.1",
-        "@sanity/color": "2.1.19-beta.3",
-        "@sanity/diff": "3.0.0-rc.2",
+        "@sanity/color": "^2.1.20",
+        "@sanity/diff": "3.0.0",
         "@sanity/eventsource": "^3.0.1",
-        "@sanity/export": "3.0.0-rc.2",
+        "@sanity/export": "3.0.0",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/icons": "1.3.9-beta.3",
+        "@sanity/icons": "^2.0.0",
         "@sanity/image-url": "^1.0.1",
-        "@sanity/import": "3.0.0-rc.2",
-        "@sanity/logos": "1.1.20-beta.3",
-        "@sanity/mutator": "3.0.0-rc.2",
-        "@sanity/portable-text-editor": "3.0.0-rc.2",
-        "@sanity/schema": "3.0.0-rc.2",
-        "@sanity/server": "3.0.0-rc.2",
-        "@sanity/types": "3.0.0-rc.2",
-        "@sanity/ui": "1.0.0-beta.32",
-        "@sanity/util": "3.0.0-rc.2",
+        "@sanity/import": "3.0.0",
+        "@sanity/logos": "^2.0.2",
+        "@sanity/mutator": "3.0.0",
+        "@sanity/portable-text-editor": "3.0.0",
+        "@sanity/schema": "3.0.0",
+        "@sanity/server": "3.0.0",
+        "@sanity/types": "3.0.0",
+        "@sanity/ui": "^1.0.0",
+        "@sanity/util": "3.0.0",
         "@sanity/uuid": "^3.0.1",
-        "@sanity/validation": "3.0.0-rc.2",
+        "@sanity/validation": "3.0.0",
         "@tanstack/react-virtual": "3.0.0-beta.18",
         "@types/is-hotkey": "^0.1.7",
         "@types/react-copy-to-clipboard": "^5.0.2",
@@ -16492,17 +16501,14 @@
         "sanity": "dev-preview || 3.0.0-rc.2"
       }
     },
-    "node_modules/sanity/node_modules/@sanity/color": {
-      "version": "2.1.19-beta.3",
-      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.19-beta.3.tgz",
-      "integrity": "sha512-421F+o3BbumkPzj93wsM9VXeX4wuhrXp/B/AHVuB0uXWLEGYnrY2mBzRU44fsZGQWW4fgy139B5eV5orFzYJkA==",
-      "dev": true
-    },
     "node_modules/sanity/node_modules/@sanity/icons": {
-      "version": "1.3.9-beta.3",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.9-beta.3.tgz",
-      "integrity": "sha512-IHacaR96czI6402cBlkiKqmi7AASj3jLVYZ8dTD9caRGi0Dp7eJzI9RFp0ptJNxQYdYbZCZu0D/oEdhJfHEMGA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.0.0.tgz",
+      "integrity": "sha512-TLrJ9YXUzZeb1gijjCkERaie1LipSYfC/7KKIzJxGxPfxq+90HRklo/zzVFk45GctXFhxJRgMA5sbkCDVb9RiA==",
       "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      },
       "peerDependencies": {
         "react": "^18"
       }
@@ -18468,9 +18474,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.15.tgz",
-      "integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.16.tgz",
+      "integrity": "sha512-nyB6CH++2mSgx3GbnrJsZSxzne5K0HMyNIWafDHqYy7IwxFc4fd/CgHVZXr8Eh+Q3KbIAcAe3vGyqIPhGblvMQ==",
       "cpu": [
         "arm"
       ],
@@ -18484,9 +18490,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
-      "integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.16.tgz",
+      "integrity": "sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==",
       "cpu": [
         "loong64"
       ],
@@ -18500,9 +18506,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
-      "integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.16.tgz",
+      "integrity": "sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -18512,34 +18518,34 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.15.15",
-        "@esbuild/linux-loong64": "0.15.15",
-        "esbuild-android-64": "0.15.15",
-        "esbuild-android-arm64": "0.15.15",
-        "esbuild-darwin-64": "0.15.15",
-        "esbuild-darwin-arm64": "0.15.15",
-        "esbuild-freebsd-64": "0.15.15",
-        "esbuild-freebsd-arm64": "0.15.15",
-        "esbuild-linux-32": "0.15.15",
-        "esbuild-linux-64": "0.15.15",
-        "esbuild-linux-arm": "0.15.15",
-        "esbuild-linux-arm64": "0.15.15",
-        "esbuild-linux-mips64le": "0.15.15",
-        "esbuild-linux-ppc64le": "0.15.15",
-        "esbuild-linux-riscv64": "0.15.15",
-        "esbuild-linux-s390x": "0.15.15",
-        "esbuild-netbsd-64": "0.15.15",
-        "esbuild-openbsd-64": "0.15.15",
-        "esbuild-sunos-64": "0.15.15",
-        "esbuild-windows-32": "0.15.15",
-        "esbuild-windows-64": "0.15.15",
-        "esbuild-windows-arm64": "0.15.15"
+        "@esbuild/android-arm": "0.15.16",
+        "@esbuild/linux-loong64": "0.15.16",
+        "esbuild-android-64": "0.15.16",
+        "esbuild-android-arm64": "0.15.16",
+        "esbuild-darwin-64": "0.15.16",
+        "esbuild-darwin-arm64": "0.15.16",
+        "esbuild-freebsd-64": "0.15.16",
+        "esbuild-freebsd-arm64": "0.15.16",
+        "esbuild-linux-32": "0.15.16",
+        "esbuild-linux-64": "0.15.16",
+        "esbuild-linux-arm": "0.15.16",
+        "esbuild-linux-arm64": "0.15.16",
+        "esbuild-linux-mips64le": "0.15.16",
+        "esbuild-linux-ppc64le": "0.15.16",
+        "esbuild-linux-riscv64": "0.15.16",
+        "esbuild-linux-s390x": "0.15.16",
+        "esbuild-netbsd-64": "0.15.16",
+        "esbuild-openbsd-64": "0.15.16",
+        "esbuild-sunos-64": "0.15.16",
+        "esbuild-windows-32": "0.15.16",
+        "esbuild-windows-64": "0.15.16",
+        "esbuild-windows-arm64": "0.15.16"
       }
     },
     "node_modules/vite/node_modules/esbuild-android-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.15.tgz",
-      "integrity": "sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.16.tgz",
+      "integrity": "sha512-Vwkv/sT0zMSgPSVO3Jlt1pUbnZuOgtOQJkJkyyJFAlLe7BiT8e9ESzo0zQSx4c3wW4T6kGChmKDPMbWTgtliQA==",
       "cpu": [
         "x64"
       ],
@@ -18553,9 +18559,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-android-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.15.tgz",
-      "integrity": "sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.16.tgz",
+      "integrity": "sha512-lqfKuofMExL5niNV3gnhMUYacSXfsvzTa/58sDlBET/hCOG99Zmeh+lz6kvdgvGOsImeo6J9SW21rFCogNPLxg==",
       "cpu": [
         "arm64"
       ],
@@ -18569,9 +18575,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-darwin-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.15.tgz",
-      "integrity": "sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.16.tgz",
+      "integrity": "sha512-wo2VWk/n/9V2TmqUZ/KpzRjCEcr00n7yahEdmtzlrfQ3lfMCf3Wa+0sqHAbjk3C6CKkR3WKK/whkMq5Gj4Da9g==",
       "cpu": [
         "x64"
       ],
@@ -18585,9 +18591,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-darwin-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
-      "integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.16.tgz",
+      "integrity": "sha512-fMXaUr5ou0M4WnewBKsspMtX++C1yIa3nJ5R2LSbLCfJT3uFdcRoU/NZjoM4kOMKyOD9Sa/2vlgN8G07K3SJnw==",
       "cpu": [
         "arm64"
       ],
@@ -18601,9 +18607,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-freebsd-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.15.tgz",
-      "integrity": "sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.16.tgz",
+      "integrity": "sha512-UzIc0xlRx5x9kRuMr+E3+hlSOxa/aRqfuMfiYBXu2jJ8Mzej4lGL7+o6F5hzhLqWfWm1GWHNakIdlqg1ayaTNQ==",
       "cpu": [
         "x64"
       ],
@@ -18617,9 +18623,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-freebsd-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.15.tgz",
-      "integrity": "sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.16.tgz",
+      "integrity": "sha512-8xyiYuGc0DLZphFQIiYaLHlfoP+hAN9RHbE+Ibh8EUcDNHAqbQgUrQg7pE7Bo00rXmQ5Ap6KFgcR0b4ALZls1g==",
       "cpu": [
         "arm64"
       ],
@@ -18633,9 +18639,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-linux-32": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.15.tgz",
-      "integrity": "sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.16.tgz",
+      "integrity": "sha512-iGijUTV+0kIMyUVoynK0v+32Oi8yyp0xwMzX69GX+5+AniNy/C/AL1MjFTsozRp/3xQPl7jVux/PLe2ds10/2w==",
       "cpu": [
         "ia32"
       ],
@@ -18649,9 +18655,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-linux-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.15.tgz",
-      "integrity": "sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.16.tgz",
+      "integrity": "sha512-tuSOjXdLw7VzaUj89fIdAaQT7zFGbKBcz4YxbWrOiXkwscYgE7HtTxUavreBbnRkGxKwr9iT/gmeJWNm4djy/g==",
       "cpu": [
         "x64"
       ],
@@ -18665,9 +18671,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-linux-arm": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.15.tgz",
-      "integrity": "sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.16.tgz",
+      "integrity": "sha512-XKcrxCEXDTOuoRj5l12tJnkvuxXBMKwEC5j0JISw3ziLf0j4zIwXbKbTmUrKFWbo6ZgvNpa7Y5dnbsjVvH39bQ==",
       "cpu": [
         "arm"
       ],
@@ -18681,9 +18687,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-linux-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.15.tgz",
-      "integrity": "sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.16.tgz",
+      "integrity": "sha512-mPYksnfHnemNrvjrDhZyixL/AfbJN0Xn9S34ZOHYdh6/jJcNd8iTsv3JwJoEvTJqjMggjMhGUPJAdjnFBHoH8A==",
       "cpu": [
         "arm64"
       ],
@@ -18697,9 +18703,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-linux-mips64le": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.15.tgz",
-      "integrity": "sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.16.tgz",
+      "integrity": "sha512-kSJO2PXaxfm0pWY39+YX+QtpFqyyrcp0ZeI8QPTrcFVQoWEPiPVtOfTZeS3ZKedfH+Ga38c4DSzmKMQJocQv6A==",
       "cpu": [
         "mips64el"
       ],
@@ -18713,9 +18719,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-linux-ppc64le": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.15.tgz",
-      "integrity": "sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.16.tgz",
+      "integrity": "sha512-NimPikwkBY0yGABw6SlhKrtT35sU4O23xkhlrTT/O6lSxv3Pm5iSc6OYaqVAHWkLdVf31bF4UDVFO+D990WpAA==",
       "cpu": [
         "ppc64"
       ],
@@ -18729,9 +18735,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-linux-riscv64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.15.tgz",
-      "integrity": "sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.16.tgz",
+      "integrity": "sha512-ty2YUHZlwFOwp7pR+J87M4CVrXJIf5ZZtU/umpxgVJBXvWjhziSLEQxvl30SYfUPq0nzeWKBGw5i/DieiHeKfw==",
       "cpu": [
         "riscv64"
       ],
@@ -18745,9 +18751,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-linux-s390x": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.15.tgz",
-      "integrity": "sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.16.tgz",
+      "integrity": "sha512-VkZaGssvPDQtx4fvVdZ9czezmyWyzpQhEbSNsHZZN0BHvxRLOYAQ7sjay8nMQwYswP6O2KlZluRMNPYefFRs+w==",
       "cpu": [
         "s390x"
       ],
@@ -18761,9 +18767,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-netbsd-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.15.tgz",
-      "integrity": "sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.16.tgz",
+      "integrity": "sha512-ElQ9rhdY51et6MJTWrCPbqOd/YuPowD7Cxx3ee8wlmXQQVW7UvQI6nSprJ9uVFQISqSF5e5EWpwWqXZsECLvXg==",
       "cpu": [
         "x64"
       ],
@@ -18777,9 +18783,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-openbsd-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.15.tgz",
-      "integrity": "sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.16.tgz",
+      "integrity": "sha512-KgxMHyxMCT+NdLQE1zVJEsLSt2QQBAvJfmUGDmgEq8Fvjrf6vSKB00dVHUEDKcJwMID6CdgCpvYNt999tIYhqA==",
       "cpu": [
         "x64"
       ],
@@ -18793,9 +18799,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-sunos-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.15.tgz",
-      "integrity": "sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.16.tgz",
+      "integrity": "sha512-exSAx8Phj7QylXHlMfIyEfNrmqnLxFqLxdQF6MBHPdHAjT7fsKaX6XIJn+aQEFiOcE4X8e7VvdMCJ+WDZxjSRQ==",
       "cpu": [
         "x64"
       ],
@@ -18809,9 +18815,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-windows-32": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.15.tgz",
-      "integrity": "sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.16.tgz",
+      "integrity": "sha512-zQgWpY5pUCSTOwqKQ6/vOCJfRssTvxFuEkpB4f2VUGPBpdddZfdj8hbZuFRdZRPIVHvN7juGcpgCA/XCF37mAQ==",
       "cpu": [
         "ia32"
       ],
@@ -18825,9 +18831,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-windows-64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.15.tgz",
-      "integrity": "sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.16.tgz",
+      "integrity": "sha512-HjW1hHRLSncnM3MBCP7iquatHVJq9l0S2xxsHHj4yzf4nm9TU4Z7k4NkeMlD/dHQ4jPlQQhwcMvwbJiOefSuZw==",
       "cpu": [
         "x64"
       ],
@@ -18841,9 +18847,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild-windows-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.15.tgz",
-      "integrity": "sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz",
+      "integrity": "sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==",
       "cpu": [
         "arm64"
       ],
@@ -21649,9 +21655,9 @@
       }
     },
     "@sanity/block-tools": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0-rc.2.tgz",
-      "integrity": "sha512-JWC4LuN1q51+KM+YlpML3nEK0ElVTvfLrfbVjBUtPhTPaaOydKBacImEusfCMHLmDc2TP0Ua44/qUiYYWZ07UA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.0.0.tgz",
+      "integrity": "sha512-c+QcM42zOqIcuwZOPQJRKAw4f0JBWmwo5B+r8U01WbDQ/nrDz35i/xMa4N2qVuwtV+Cclv6WYa9XbfGQP/8Mig==",
       "dev": true,
       "requires": {
         "get-random-values-esm": "^1.0.0",
@@ -21659,9 +21665,9 @@
       }
     },
     "@sanity/cli": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.0.0-rc.2.tgz",
-      "integrity": "sha512-umWFPQu7j7a2OuROyvAVy1El2hsVg33UbmUnmhzxsobFE38mMPXf4HhRliyvA/fIeeNalOBO+MWJpGxo7dZf3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.0.0.tgz",
+      "integrity": "sha512-YEFZYQvA9DhHcCR5YHMy7mCpb31i0Zyo2umhp8RIKjWSD7hYYh2HZh0traW4GdKWVQ4GYXUoOd1m8OkGOFaeHw==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.19.0",
@@ -21843,10 +21849,15 @@
         }
       }
     },
+    "@sanity/color": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.20.tgz",
+      "integrity": "sha512-dHPgiCMf+lwvQls5uPzorfiq9YuU41AzvifA+ugVHmXvq7JBoofoOPUOmdHUQF0l0shSy0nD3zn52j2I+T2ekg=="
+    },
     "@sanity/diff": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.0.0-rc.2.tgz",
-      "integrity": "sha512-etgoHJQYK5X6TDoQXEO4FjVdc8qUuhTyjbnYNkqEb/MC7Dwc3Dy7JFm8IRwiB/qfGASxH6d7NnFlV0+wCccveQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.0.0.tgz",
+      "integrity": "sha512-tE1lL963nR1fJmy6uHnyVVCDym+CeZe/H8q0I2YpeCIoR7rA25tXQxD4NsBwKtO1d1eY2zBofXqq4JUakNBjuQ==",
       "dev": true,
       "requires": {
         "diff-match-patch": "^1.0.4"
@@ -21863,9 +21874,9 @@
       }
     },
     "@sanity/export": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.0.0-rc.2.tgz",
-      "integrity": "sha512-iqIDQHsgeAV3Nkue6Y1XJ5rxwQQR02AEUeCrLq+167wg4KmSogfoqj+E6PVp5eDrvKmwziVKGkWwFT/97PB5Zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.0.0.tgz",
+      "integrity": "sha512-iemJZ9xdW8dliptNg+X2/04EX0vfW4l3VzEWDb6ZvKF+GhpJ2/QwAiI398wCYmDHzEicugFoK29HQVtFk07EYA==",
       "dev": true,
       "requires": {
         "archiver": "^5.0.0",
@@ -21986,14 +21997,14 @@
       "dev": true
     },
     "@sanity/import": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.0.0-rc.2.tgz",
-      "integrity": "sha512-6eB/eG1QXsw3CyK78rsKcqDTj2jipoyhxckDWbM1gAk4dutNQENCgCAkWOtuGda5vKcU8KeVooUVHopTlbFYJA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.0.0.tgz",
+      "integrity": "sha512-n+3wJa1Uu13FPsmf29sQ1L3D64BuiMKboN3ZZwp1e0u/k6ALb9NUeIiqqttk8nW+TUz8dnkRngJMUPIsj4pltg==",
       "dev": true,
       "requires": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.0.0-rc.2",
+        "@sanity/mutator": "3.0.0",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -22133,15 +22144,15 @@
       }
     },
     "@sanity/logos": {
-      "version": "1.1.20-beta.3",
-      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-1.1.20-beta.3.tgz",
-      "integrity": "sha512-aMxqGIemeO12BxbpWD+5dQeTK2maYRsLa4f5cdr+ah9uyfooNTmpz9vQlSaukyUIKG+Skzx+aMzj1qWjzB2pig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-2.0.2.tgz",
+      "integrity": "sha512-BsBNt4ldWNAuKeHge4nKHnN43BN8BwLJuf+HDhrg/ngnORUjty5WV4KVoQkQ2FSTv5YtpJjSuNGSXwT+Araegw==",
       "dev": true
     },
     "@sanity/mutator": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.0.0-rc.2.tgz",
-      "integrity": "sha512-bmX8lE+gxz/ws2D6cewqWprJFHQX46kFKvdIx5cqYZElIp9GDrY9ICk5exSfQgiTA4FW1AiHIY6EGVM8kqbNwQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.0.0.tgz",
+      "integrity": "sha512-U0Jm5BE4WSMnuy8dPOApLiFpaJ5B+L1wXRQ1558iPXc2r1cX2ISWBQTcJHRNQO1Gd1SUWGjDwNs6YbUxH4cGpA==",
       "dev": true,
       "requires": {
         "@sanity/uuid": "^3.0.1",
@@ -22445,16 +22456,16 @@
       }
     },
     "@sanity/portable-text-editor": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.0.0-rc.2.tgz",
-      "integrity": "sha512-hpu/rQuKwWTYPU5V4vKmrDZQzuhM+IuBC3W5M3l5Mmijqx+xll2fKqX9uKdR1a+kuuDgu/n74nLBHVzOI5vF0g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.0.0.tgz",
+      "integrity": "sha512-72x1d1ojV7ioOF1pmPolc6By2XxdZI7vJV0XvtD8RbBsitBWdTuvXteSnumLVP8qm/JO11WBA75BdgofdtpkEA==",
       "dev": true,
       "requires": {
-        "@sanity/block-tools": "3.0.0-rc.2",
-        "@sanity/schema": "3.0.0-rc.2",
+        "@sanity/block-tools": "3.0.0",
+        "@sanity/schema": "3.0.0",
         "@sanity/slate-react": "2.30.1",
-        "@sanity/types": "3.0.0-rc.2",
-        "@sanity/util": "3.0.0-rc.2",
+        "@sanity/types": "3.0.0",
+        "@sanity/util": "3.0.0",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -22473,13 +22484,13 @@
       }
     },
     "@sanity/schema": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.0.0-rc.2.tgz",
-      "integrity": "sha512-cBgSmx4EY3WizUn9zjueu1HXu1b/FgeQmvjPltXBwmzjHTvlBBlyyg/pIO9qpLFMEU9lO3H1+JExlNL6boRCGw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.0.0.tgz",
+      "integrity": "sha512-SPnlbA4Vx/RjtPdLSmGml6jB9Pw4zbKNfNJfTq97vVn7lFh93wpsQ4NNMzUPKTLYvEIfPLq/Bz1YpANoSpGT1w==",
       "dev": true,
       "requires": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.0.0-rc.2",
+        "@sanity/types": "3.0.0",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -22502,9 +22513,9 @@
       }
     },
     "@sanity/server": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/server/-/server-3.0.0-rc.2.tgz",
-      "integrity": "sha512-mD50vHzDSk4N/jxpTspQPGGmpYxJHANqSstorJnHGbRSOXGVS5/wSCJ26bU/1jXzZini73uRTQrNenN/577cpQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/server/-/server-3.0.0.tgz",
+      "integrity": "sha512-F4CCt6MBmf+F368mSrUtmnr+JMYxY3Egr70/NFlDiAVq1uCx/XojadyikFSJnT7yMjdq5vTCIR28kQlykJAtdQ==",
       "dev": true,
       "requires": {
         "@sanity/generate-help-url": "^3.0.0",
@@ -22562,36 +22573,32 @@
       "dev": true
     },
     "@sanity/types": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0-rc.2.tgz",
-      "integrity": "sha512-0zZPU3lrTblkVbaPQs/xQohxT3sSdcfDdU3TRh1Ip78MGU/l9YMMCbHTrbaP0J//FTicYR5AaKxeG4UW/4xrfw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-I+M3sdwxjZLR0BcbMubvSPSxc84hm0Pu3L5go87RwGCRKnGF0eU3KclxByloIE6XdLs9f8sGaXC4D9UUdKVWMA==",
       "dev": true,
       "requires": {
         "@sanity/client": "^3.4.1",
-        "@types/react": "^18.0.21"
+        "@types/react": "^18.0.25"
       }
     },
     "@sanity/ui": {
-      "version": "1.0.0-beta.32",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.0.0-beta.32.tgz",
-      "integrity": "sha512-mzJXwdevJr/LAPnXHFnkhs4fXEuS7uDQqnvPRdX9t76GG9diyW5TOBemsujuFk4qFRKRUzgFDM3CyqllWbL2zw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.0.0.tgz",
+      "integrity": "sha512-Ru0ZaKValcOsSj3yaC1G+oBn+t4egtSMnrw22cg3fpuDvWN7Oj4cZVaTUBmggUDSeP8+wsSO3crZ87aHC9H1Hw==",
       "requires": {
         "@floating-ui/react-dom": "^1.0.0",
-        "@sanity/color": "2.1.19-beta.3",
-        "@sanity/icons": "1.3.9-beta.3",
+        "@sanity/color": "^2.1.20",
+        "@sanity/icons": "^2.0.0",
+        "csstype": "^3.1.1",
         "framer-motion": "^7.5.3",
         "react-refractor": "^2.1.7"
       },
       "dependencies": {
-        "@sanity/color": {
-          "version": "2.1.19-beta.3",
-          "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.19-beta.3.tgz",
-          "integrity": "sha512-421F+o3BbumkPzj93wsM9VXeX4wuhrXp/B/AHVuB0uXWLEGYnrY2mBzRU44fsZGQWW4fgy139B5eV5orFzYJkA=="
-        },
         "@sanity/icons": {
-          "version": "1.3.9-beta.3",
-          "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.9-beta.3.tgz",
-          "integrity": "sha512-IHacaR96czI6402cBlkiKqmi7AASj3jLVYZ8dTD9caRGi0Dp7eJzI9RFp0ptJNxQYdYbZCZu0D/oEdhJfHEMGA=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.0.0.tgz",
+          "integrity": "sha512-TLrJ9YXUzZeb1gijjCkERaie1LipSYfC/7KKIzJxGxPfxq+90HRklo/zzVFk45GctXFhxJRgMA5sbkCDVb9RiA=="
         },
         "framer-motion": {
           "version": "7.6.7",
@@ -22638,12 +22645,12 @@
       }
     },
     "@sanity/util": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.0.0-rc.2.tgz",
-      "integrity": "sha512-3JmfSKVyb+Y/rv1zvFjr+mG9yWGNGiqNtycvPRITf2LLKiooqZfxD9xX6ZTDZgI4+IyXgTimqgbbZAAsNrE1jw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-UqE1E9KPwq8Ym3wcD8SXGSuXp5HlZMsNxsE0wD3eecPEOD9Z1gYU2p7AaTO81+gp4fOWCQbWdsZWrNi6XQF3rA==",
       "dev": true,
       "requires": {
-        "@sanity/types": "3.0.0-rc.2",
+        "@sanity/types": "3.0.0",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       }
@@ -22658,12 +22665,12 @@
       }
     },
     "@sanity/validation": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.0.0-rc.2.tgz",
-      "integrity": "sha512-v0JPfK9t8HJ7XriYyQbJItI9Jfrf5BVAGjRwTrAVKTrCyghNzjNJSok7yNR9EDIYDNxrKh+EGrW2JQkfEPlSgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/validation/-/validation-3.0.0.tgz",
+      "integrity": "sha512-Qj2qnJ+MsnVohURsNuYmAYNW+oh60NJUZlVPTx2oUdkJtzDYmMc2dIy9R1BjItI3V1QxNFU/tUcvqAPiGvULCg==",
       "dev": true,
       "requires": {
-        "@sanity/types": "3.0.0-rc.2",
+        "@sanity/types": "3.0.0",
         "date-fns": "^2.26.1",
         "lodash": "^4.17.21",
         "rxjs": "^6.5.3"
@@ -23004,9 +23011,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.189",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
-      "integrity": "sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==",
+      "version": "4.14.190",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.190.tgz",
+      "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==",
       "dev": true
     },
     "@types/minimatch": {
@@ -24459,8 +24466,7 @@
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -31291,9 +31297,9 @@
       "dev": true
     },
     "sanity": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.0.0-rc.2.tgz",
-      "integrity": "sha512-ZT4ZTsoFCGlpAFz6h4hYBRNwXCDKub3WxRa6B3nx87nS7DvwNB5w/b3FJfjwfGD2EZzgZJsfw1EEqySxuelS5A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.0.0.tgz",
+      "integrity": "sha512-90Y143rQntPYVYo9l8N6sf6GUQFAxagIvJ95k4/Xwz/ATpEEVVVFLAMwKj0IF461sjnyBzmEvX7kYngP7AINlQ==",
       "dev": true,
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
@@ -31303,27 +31309,27 @@
         "@rexxars/react-sortable-hoc": "^2.0.0",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.0",
-        "@sanity/block-tools": "3.0.0-rc.2",
-        "@sanity/cli": "3.0.0-rc.2",
+        "@sanity/block-tools": "3.0.0",
+        "@sanity/cli": "3.0.0",
         "@sanity/client": "^3.4.1",
-        "@sanity/color": "2.1.19-beta.3",
-        "@sanity/diff": "3.0.0-rc.2",
+        "@sanity/color": "^2.1.20",
+        "@sanity/diff": "3.0.0",
         "@sanity/eventsource": "^3.0.1",
-        "@sanity/export": "3.0.0-rc.2",
+        "@sanity/export": "3.0.0",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/icons": "1.3.9-beta.3",
+        "@sanity/icons": "^2.0.0",
         "@sanity/image-url": "^1.0.1",
-        "@sanity/import": "3.0.0-rc.2",
-        "@sanity/logos": "1.1.20-beta.3",
-        "@sanity/mutator": "3.0.0-rc.2",
-        "@sanity/portable-text-editor": "3.0.0-rc.2",
-        "@sanity/schema": "3.0.0-rc.2",
-        "@sanity/server": "3.0.0-rc.2",
-        "@sanity/types": "3.0.0-rc.2",
-        "@sanity/ui": "1.0.0-beta.32",
-        "@sanity/util": "3.0.0-rc.2",
+        "@sanity/import": "3.0.0",
+        "@sanity/logos": "^2.0.2",
+        "@sanity/mutator": "3.0.0",
+        "@sanity/portable-text-editor": "3.0.0",
+        "@sanity/schema": "3.0.0",
+        "@sanity/server": "3.0.0",
+        "@sanity/types": "3.0.0",
+        "@sanity/ui": "^1.0.0",
+        "@sanity/util": "3.0.0",
         "@sanity/uuid": "^3.0.1",
-        "@sanity/validation": "3.0.0-rc.2",
+        "@sanity/validation": "3.0.0",
         "@tanstack/react-virtual": "3.0.0-beta.18",
         "@types/is-hotkey": "^0.1.7",
         "@types/react-copy-to-clipboard": "^5.0.2",
@@ -31394,16 +31400,10 @@
         "yargs": "^17.3.0"
       },
       "dependencies": {
-        "@sanity/color": {
-          "version": "2.1.19-beta.3",
-          "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.1.19-beta.3.tgz",
-          "integrity": "sha512-421F+o3BbumkPzj93wsM9VXeX4wuhrXp/B/AHVuB0uXWLEGYnrY2mBzRU44fsZGQWW4fgy139B5eV5orFzYJkA==",
-          "dev": true
-        },
         "@sanity/icons": {
-          "version": "1.3.9-beta.3",
-          "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.3.9-beta.3.tgz",
-          "integrity": "sha512-IHacaR96czI6402cBlkiKqmi7AASj3jLVYZ8dTD9caRGi0Dp7eJzI9RFp0ptJNxQYdYbZCZu0D/oEdhJfHEMGA==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.0.0.tgz",
+          "integrity": "sha512-TLrJ9YXUzZeb1gijjCkERaie1LipSYfC/7KKIzJxGxPfxq+90HRklo/zzVFk45GctXFhxJRgMA5sbkCDVb9RiA==",
           "dev": true
         },
         "ansi-styles": {
@@ -32928,186 +32928,186 @@
       },
       "dependencies": {
         "@esbuild/android-arm": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.15.tgz",
-          "integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.16.tgz",
+          "integrity": "sha512-nyB6CH++2mSgx3GbnrJsZSxzne5K0HMyNIWafDHqYy7IwxFc4fd/CgHVZXr8Eh+Q3KbIAcAe3vGyqIPhGblvMQ==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-loong64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
-          "integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.16.tgz",
+          "integrity": "sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==",
           "dev": true,
           "optional": true
         },
         "esbuild": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
-          "integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.16.tgz",
+          "integrity": "sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==",
           "dev": true,
           "requires": {
-            "@esbuild/android-arm": "0.15.15",
-            "@esbuild/linux-loong64": "0.15.15",
-            "esbuild-android-64": "0.15.15",
-            "esbuild-android-arm64": "0.15.15",
-            "esbuild-darwin-64": "0.15.15",
-            "esbuild-darwin-arm64": "0.15.15",
-            "esbuild-freebsd-64": "0.15.15",
-            "esbuild-freebsd-arm64": "0.15.15",
-            "esbuild-linux-32": "0.15.15",
-            "esbuild-linux-64": "0.15.15",
-            "esbuild-linux-arm": "0.15.15",
-            "esbuild-linux-arm64": "0.15.15",
-            "esbuild-linux-mips64le": "0.15.15",
-            "esbuild-linux-ppc64le": "0.15.15",
-            "esbuild-linux-riscv64": "0.15.15",
-            "esbuild-linux-s390x": "0.15.15",
-            "esbuild-netbsd-64": "0.15.15",
-            "esbuild-openbsd-64": "0.15.15",
-            "esbuild-sunos-64": "0.15.15",
-            "esbuild-windows-32": "0.15.15",
-            "esbuild-windows-64": "0.15.15",
-            "esbuild-windows-arm64": "0.15.15"
+            "@esbuild/android-arm": "0.15.16",
+            "@esbuild/linux-loong64": "0.15.16",
+            "esbuild-android-64": "0.15.16",
+            "esbuild-android-arm64": "0.15.16",
+            "esbuild-darwin-64": "0.15.16",
+            "esbuild-darwin-arm64": "0.15.16",
+            "esbuild-freebsd-64": "0.15.16",
+            "esbuild-freebsd-arm64": "0.15.16",
+            "esbuild-linux-32": "0.15.16",
+            "esbuild-linux-64": "0.15.16",
+            "esbuild-linux-arm": "0.15.16",
+            "esbuild-linux-arm64": "0.15.16",
+            "esbuild-linux-mips64le": "0.15.16",
+            "esbuild-linux-ppc64le": "0.15.16",
+            "esbuild-linux-riscv64": "0.15.16",
+            "esbuild-linux-s390x": "0.15.16",
+            "esbuild-netbsd-64": "0.15.16",
+            "esbuild-openbsd-64": "0.15.16",
+            "esbuild-sunos-64": "0.15.16",
+            "esbuild-windows-32": "0.15.16",
+            "esbuild-windows-64": "0.15.16",
+            "esbuild-windows-arm64": "0.15.16"
           }
         },
         "esbuild-android-64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.15.tgz",
-          "integrity": "sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.16.tgz",
+          "integrity": "sha512-Vwkv/sT0zMSgPSVO3Jlt1pUbnZuOgtOQJkJkyyJFAlLe7BiT8e9ESzo0zQSx4c3wW4T6kGChmKDPMbWTgtliQA==",
           "dev": true,
           "optional": true
         },
         "esbuild-android-arm64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.15.tgz",
-          "integrity": "sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.16.tgz",
+          "integrity": "sha512-lqfKuofMExL5niNV3gnhMUYacSXfsvzTa/58sDlBET/hCOG99Zmeh+lz6kvdgvGOsImeo6J9SW21rFCogNPLxg==",
           "dev": true,
           "optional": true
         },
         "esbuild-darwin-64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.15.tgz",
-          "integrity": "sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.16.tgz",
+          "integrity": "sha512-wo2VWk/n/9V2TmqUZ/KpzRjCEcr00n7yahEdmtzlrfQ3lfMCf3Wa+0sqHAbjk3C6CKkR3WKK/whkMq5Gj4Da9g==",
           "dev": true,
           "optional": true
         },
         "esbuild-darwin-arm64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
-          "integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.16.tgz",
+          "integrity": "sha512-fMXaUr5ou0M4WnewBKsspMtX++C1yIa3nJ5R2LSbLCfJT3uFdcRoU/NZjoM4kOMKyOD9Sa/2vlgN8G07K3SJnw==",
           "dev": true,
           "optional": true
         },
         "esbuild-freebsd-64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.15.tgz",
-          "integrity": "sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.16.tgz",
+          "integrity": "sha512-UzIc0xlRx5x9kRuMr+E3+hlSOxa/aRqfuMfiYBXu2jJ8Mzej4lGL7+o6F5hzhLqWfWm1GWHNakIdlqg1ayaTNQ==",
           "dev": true,
           "optional": true
         },
         "esbuild-freebsd-arm64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.15.tgz",
-          "integrity": "sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.16.tgz",
+          "integrity": "sha512-8xyiYuGc0DLZphFQIiYaLHlfoP+hAN9RHbE+Ibh8EUcDNHAqbQgUrQg7pE7Bo00rXmQ5Ap6KFgcR0b4ALZls1g==",
           "dev": true,
           "optional": true
         },
         "esbuild-linux-32": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.15.tgz",
-          "integrity": "sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.16.tgz",
+          "integrity": "sha512-iGijUTV+0kIMyUVoynK0v+32Oi8yyp0xwMzX69GX+5+AniNy/C/AL1MjFTsozRp/3xQPl7jVux/PLe2ds10/2w==",
           "dev": true,
           "optional": true
         },
         "esbuild-linux-64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.15.tgz",
-          "integrity": "sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.16.tgz",
+          "integrity": "sha512-tuSOjXdLw7VzaUj89fIdAaQT7zFGbKBcz4YxbWrOiXkwscYgE7HtTxUavreBbnRkGxKwr9iT/gmeJWNm4djy/g==",
           "dev": true,
           "optional": true
         },
         "esbuild-linux-arm": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.15.tgz",
-          "integrity": "sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.16.tgz",
+          "integrity": "sha512-XKcrxCEXDTOuoRj5l12tJnkvuxXBMKwEC5j0JISw3ziLf0j4zIwXbKbTmUrKFWbo6ZgvNpa7Y5dnbsjVvH39bQ==",
           "dev": true,
           "optional": true
         },
         "esbuild-linux-arm64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.15.tgz",
-          "integrity": "sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.16.tgz",
+          "integrity": "sha512-mPYksnfHnemNrvjrDhZyixL/AfbJN0Xn9S34ZOHYdh6/jJcNd8iTsv3JwJoEvTJqjMggjMhGUPJAdjnFBHoH8A==",
           "dev": true,
           "optional": true
         },
         "esbuild-linux-mips64le": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.15.tgz",
-          "integrity": "sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.16.tgz",
+          "integrity": "sha512-kSJO2PXaxfm0pWY39+YX+QtpFqyyrcp0ZeI8QPTrcFVQoWEPiPVtOfTZeS3ZKedfH+Ga38c4DSzmKMQJocQv6A==",
           "dev": true,
           "optional": true
         },
         "esbuild-linux-ppc64le": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.15.tgz",
-          "integrity": "sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.16.tgz",
+          "integrity": "sha512-NimPikwkBY0yGABw6SlhKrtT35sU4O23xkhlrTT/O6lSxv3Pm5iSc6OYaqVAHWkLdVf31bF4UDVFO+D990WpAA==",
           "dev": true,
           "optional": true
         },
         "esbuild-linux-riscv64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.15.tgz",
-          "integrity": "sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.16.tgz",
+          "integrity": "sha512-ty2YUHZlwFOwp7pR+J87M4CVrXJIf5ZZtU/umpxgVJBXvWjhziSLEQxvl30SYfUPq0nzeWKBGw5i/DieiHeKfw==",
           "dev": true,
           "optional": true
         },
         "esbuild-linux-s390x": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.15.tgz",
-          "integrity": "sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.16.tgz",
+          "integrity": "sha512-VkZaGssvPDQtx4fvVdZ9czezmyWyzpQhEbSNsHZZN0BHvxRLOYAQ7sjay8nMQwYswP6O2KlZluRMNPYefFRs+w==",
           "dev": true,
           "optional": true
         },
         "esbuild-netbsd-64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.15.tgz",
-          "integrity": "sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.16.tgz",
+          "integrity": "sha512-ElQ9rhdY51et6MJTWrCPbqOd/YuPowD7Cxx3ee8wlmXQQVW7UvQI6nSprJ9uVFQISqSF5e5EWpwWqXZsECLvXg==",
           "dev": true,
           "optional": true
         },
         "esbuild-openbsd-64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.15.tgz",
-          "integrity": "sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.16.tgz",
+          "integrity": "sha512-KgxMHyxMCT+NdLQE1zVJEsLSt2QQBAvJfmUGDmgEq8Fvjrf6vSKB00dVHUEDKcJwMID6CdgCpvYNt999tIYhqA==",
           "dev": true,
           "optional": true
         },
         "esbuild-sunos-64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.15.tgz",
-          "integrity": "sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.16.tgz",
+          "integrity": "sha512-exSAx8Phj7QylXHlMfIyEfNrmqnLxFqLxdQF6MBHPdHAjT7fsKaX6XIJn+aQEFiOcE4X8e7VvdMCJ+WDZxjSRQ==",
           "dev": true,
           "optional": true
         },
         "esbuild-windows-32": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.15.tgz",
-          "integrity": "sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.16.tgz",
+          "integrity": "sha512-zQgWpY5pUCSTOwqKQ6/vOCJfRssTvxFuEkpB4f2VUGPBpdddZfdj8hbZuFRdZRPIVHvN7juGcpgCA/XCF37mAQ==",
           "dev": true,
           "optional": true
         },
         "esbuild-windows-64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.15.tgz",
-          "integrity": "sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.16.tgz",
+          "integrity": "sha512-HjW1hHRLSncnM3MBCP7iquatHVJq9l0S2xxsHHj4yzf4nm9TU4Z7k4NkeMlD/dHQ4jPlQQhwcMvwbJiOefSuZw==",
           "dev": true,
           "optional": true
         },
         "esbuild-windows-arm64": {
-          "version": "0.15.15",
-          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.15.tgz",
-          "integrity": "sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==",
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz",
+          "integrity": "sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@sanity/icons": "^1.3.6",
     "@sanity/incompatible-plugin": "^1.0.4",
-    "@sanity/ui": "1.0.0-beta.32",
+    "@sanity/ui": "^1.0.0",
     "@sanity/uuid": "^3.0.1",
     "sanity-plugin-internationalized-array": "^1.4.1",
     "sanity-plugin-utils": "^1.0.0"
@@ -74,12 +74,12 @@
     "prettier-plugin-packagejson": "^2.3.0",
     "react": "^18",
     "rimraf": "^3.0.2",
-    "sanity": "3.0.0-rc.2",
+    "sanity": "^3.0.0",
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
     "react": "^18",
-    "sanity": "dev-preview || 3.0.0-rc.2"
+    "sanity": "^3.0.0"
   },
   "engines": {
     "node": ">=14"

--- a/src/components/BulkPublish/DocumentCheck.tsx
+++ b/src/components/BulkPublish/DocumentCheck.tsx
@@ -3,7 +3,7 @@ import {Card, Spinner} from '@sanity/ui'
 import {
   useEditState,
   useValidationStatus,
-  SanityPreview as Preview,
+  Preview,
   SchemaType,
   useSchema,
 } from 'sanity'


### PR DESCRIPTION
Apparently the `SanityPreview` export has gone away, so I had to update the import to make this version work again. I have however not been able to test the code path that invokes the `Preview` so I cannot say if it is equivalent to the old `SanityPreview` export.

This needs investigation before release

The other patch here is applying the relevant versions from https://github.com/sanity-io/document-internationalization/commit/6af3ba26f355acc466da5f1912a01560cc7c8535