### PR TITLE
fix: scroll translations menu when it overflows

### DIFF
--- a/src/components/MenuButton.tsx
+++ b/src/components/MenuButton.tsx
@@ -58,7 +58,7 @@ export default function MenuButton(props: MenuButtonProps) {
   }, [supportedLanguages])
 
   const content = (
-    <Box overflow="auto">
+    <Box>
       {error ? (
         <Card tone="critical" padding={2}>
           <Text>Error: {error}</Text>
@@ -146,7 +146,7 @@ export default function MenuButton(props: MenuButtonProps) {
   )
 
   return (
-    <Popover constrainSize content={content} open={open} portal ref={setPopover}>
+    <Popover constrainSize content={content} open={open} portal ref={setPopover} overflow="auto">
       <Button
         text="Translations"
         mode="bleed"


### PR DESCRIPTION
When the language list is too long it currently doesn't overflow scroll, this fixes this.

**Current behaviour:**

https://user-images.githubusercontent.com/4410247/208300672-4a74540b-65bf-4604-a592-4ae696bb2031.mov

**With this fix:**

https://user-images.githubusercontent.com/4410247/208300692-a11fd3a2-994b-456c-8a5c-167f61a3ce41.mov

