### PR TITLE
Remove outdated warnings about v3 compatibility for language-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,11 @@ This plugin adds features to the Studio to improve handling **document-level tra
 
 For **field-level translations** you should use the [@sanity/language-filter plugin](https://www.npmjs.com/package/@sanity/language-filter).
 
-*Studio V3 note*: language-filter is not available for V3 yet.
-
 ### Many projects use both!
-
-*Studio V3 note*: language-filter is not available for V3 yet.
 
 An example of document-level translation could be a `lesson` schema, the `title`, `slug` and `content` fields would be unique in every language.
 
 A good use of field-level translation could be a `person` schema. It could have the same `name` and `image` in every language, but only the `biography` would need translating.
-
-## Studio V3 known issues
-
-Studio V3 does not implement language-filter yet. This means that the language button has moved into the document editor flow for the time being.
-We will be looking to restore the button placement during Studio V3 dev-preview. 
 
 ## Installation
 


### PR DESCRIPTION
Since the [language-filter](https://github.com/sanity-io/language-filter) plugin is available and supported for Studio v3, I believe these warnings can be removed now.