### PR TITLE
Update usage-with-custom-publish.md

### DIFF
--- a/docs/usage-with-custom-publish.md
+++ b/docs/usage-with-custom-publish.md
@@ -9,7 +9,7 @@ In order to get the full functionality, you can make use of the `updateIntlField
 Example:
 
 ```js
-import {updateIntlFieldsForDocument} from '@sanity/document-internationalization'
+import {updateIntlFieldsForDocument} from '@sanity/document-internationalization/src/utils'
 
 export const CustomPublishAction = ({id, type, onComplete}) => {
   const {publish} = useDocumentOperation(id, type)


### PR DESCRIPTION
The TS compiler keeps telling me:
Module ‘“@sanity/document-internationalization”’ has no exported member ‘updateIntlFieldsForDocument’. With this import, I was able to get away from the tslint warning.