### PR TITLE
fix: reinstate 'action' property names of i18n document actions

### DIFF
--- a/src/actions/DeleteWithi18nAction.tsx
+++ b/src/actions/DeleteWithi18nAction.tsx
@@ -17,7 +17,7 @@ const DISABLED_REASON_TITLE = {
 }
 
 export function createDeleteAction(pluginConfig: Ti18nConfig): DocumentActionComponent {
-  return function DeleteWith18nAction({id, type, onComplete}): DocumentActionDescription {
+  const Action: DocumentActionComponent = ({id, type, onComplete}): DocumentActionDescription => {
     const toast = useToast()
     const client = useSanityClient()
     const config = useConfig(pluginConfig, type)
@@ -115,4 +115,9 @@ export function createDeleteAction(pluginConfig: Ti18nConfig): DocumentActionCom
       },
     }
   }
+
+  // Reset the `action` name for the newly created i18n action
+  Action.action = 'delete'
+
+  return Action
 }

--- a/src/actions/DuplicateWithi18nAction.tsx
+++ b/src/actions/DuplicateWithi18nAction.tsx
@@ -24,7 +24,12 @@ const DISABLED_REASON_TITLE = {
 }
 
 export function createDuplicateAction(pluginConfig: Ti18nConfig): DocumentActionComponent {
-  return ({id, type, draft, published}): DocumentActionDescription => {
+  const Action: DocumentActionComponent = ({
+    id,
+    type,
+    draft,
+    published,
+  }): DocumentActionDescription => {
     const toast = useToast()
     const client = useSanityClient()
     const config = useConfig(pluginConfig, type)
@@ -74,4 +79,9 @@ export function createDuplicateAction(pluginConfig: Ti18nConfig): DocumentAction
       onHandle: onDuplicate,
     }
   }
+
+  // Reset the `action` name for the newly created i18n action
+  Action.action = 'duplicate'
+
+  return Action
 }

--- a/src/actions/PublishWithi18nAction.ts
+++ b/src/actions/PublishWithi18nAction.ts
@@ -10,7 +10,7 @@ import {IEditState, IUseDocumentOperationResult, Ti18nConfig} from '../types'
 import {useConfig, useDelayedFlag} from '../hooks'
 
 export function createPublishAction(pluginConfig: Ti18nConfig): DocumentActionComponent {
-  return ({type, id, onComplete}): DocumentActionDescription => {
+  const Action: DocumentActionComponent = ({type, id, onComplete}): DocumentActionDescription => {
     const toast = useToast()
     const client = useSanityClient()
     const config = useConfig(pluginConfig, type)
@@ -115,4 +115,9 @@ export function createPublishAction(pluginConfig: Ti18nConfig): DocumentActionCo
       onHandle,
     }
   }
+
+  // Reset the `action` name for the newly created i18n action
+  Action.action = 'publish'
+
+  return Action
 }


### PR DESCRIPTION
I came across a small issue when activating document translations, as filtering document actions wasn't working properly anymore. I followed this guide: https://www.sanity.io/guides/singleton-document. The filtering of the document actions relies on the existence of an `action` property containing a name. These names go missing when using this plugin.

This PR recreates the `action` property of the action functions by resetting those properties for the replaced actions before return the action.