### PR TITLE
chore: fix broken link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ For more advanced topics see the documentation. For installation see [Usage](#us
 - [Importing and creating documents](./docs/02-importing-and-creating-documents.md)
 - [Deleting translated documents](./docs/03-deleting-translated-documents.md)
 - [Importing plugin components](./docs/04-importing-plugin-components.md)
-- [Allowing the same slug on different language versions](./docs/05-allowing-the-same-slug-on-different-language-versions.md)
+- [Allowing the same slug on different language versions](./docs/05-allowing-the-same-slug-for-translations.md)
 - [Remove default new document template](./docs/06-remove-default-new-document-template.md)
 
 ## License


### PR DESCRIPTION
fix broken link to `allowing-the-same-slug-for-translations.md`