### PR TITLE
make references weak by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ export const createConfig({
       languageField: `language` // defauts to "language"
 
       // Optional
-      // Keep translation.metadata references weak
-      weakReferences: true // defaults to false
+      // Keep translation.metadata references strong
+      weakReferences: false // defaults to true
 
       // Optional
       // Adds UI for publishing all translations at once. Requires access to the Scheduling API

--- a/docs/00-upgrade-from-v1.md
+++ b/docs/00-upgrade-from-v1.md
@@ -164,7 +164,7 @@ documentI18n({
     { "title": "Dutch (NL)", "id": "nl-nl" }
   ],
   // Change to `weakReferences`, example:
-  // weakReferences: true | false (default false)
+  // weakReferences: true | false (default true)
   "referenceBehavior": "strong",
   // Change to `languageField`, example:
   // languageField: 'language' (default 'language')

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export const DEFAULT_CONFIG: PluginConfigContext = {
   supportedLanguages: [],
   schemaTypes: [],
   languageField: `language`,
-  weakReferences: false,
+  weakReferences: true,
   bulkPublish: false,
   metadataFields: [],
   apiVersion: API_VERSION,


### PR DESCRIPTION
Deleting and unpublishing translations sounds like a basic feature to me. Do you agree?
Related issue: https://github.com/sanity-io/document-internationalization/issues/56

If we don't use weak references, we cannot delete the translations.

Finding this was not the default behaviour was a bit annoying to me as a user, so I thought I might prevent people in the future from encountering the same issue ☺️

BTW, is there any advantage to the other option?


