### PR TITLE
feat: exclude fields from duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ defineField({
 })
 ```
 
+### Excluding fields
+
+The default behaviour of this plugin when creating a new translation is to duplicate the originating document, which is useful for then translating the fields directly in the new document - perhaps with [Sanity AI Assist](https://github.com/sanity-io/assist). However, sometimes you may want to exclude certain fields from being copied to the new document. You can do this by updating your schema to exclude certain types or fields with `options.documentInternationalization.exclude`:
+
+```ts
+defineField({
+  name: 'title',
+  title: 'Title',
+  type: 'string',
+  options: {
+    documentInternationalization: {
+      exclude: true,
+    },
+  },
+}),
+```
+
 ## Querying translations
 
 ### Querying with GROQ

--- a/package.config.ts
+++ b/package.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   dist: 'dist',
   tsconfig: 'tsconfig.dist.json',
 
+  // Avoid ttyl, os and other node specific deps
+  external: ['@sanity/mutator'],
+
   // Remove this block to enable strict export validation
   extract: {
     rules: {

--- a/src/components/DocumentInternationalizationMenu.tsx
+++ b/src/components/DocumentInternationalizationMenu.tsx
@@ -25,7 +25,7 @@ export function DocumentInternationalizationMenu(
   props: DocumentInternationalizationMenuProps
 ) {
   const {documentId} = props
-  const schemaType = props.schemaType.name
+  const schemaType = props.schemaType
   const {languageField, supportedLanguages} =
     useDocumentInternationalizationContext()
 
@@ -64,7 +64,7 @@ export function DocumentInternationalizationMenu(
   }, [loading, metadata?._id])
 
   // Duplicate a new language version from the most recent version of this document
-  const {draft, published} = useEditState(documentId, schemaType)
+  const {draft, published} = useEditState(documentId, schemaType.name)
   const source = draft || published
 
   // Check for data issues
@@ -197,7 +197,7 @@ export function DocumentInternationalizationMenu(
     return null
   }
 
-  if (!schemaType) {
+  if (!schemaType || !schemaType.name) {
     return null
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 import type {
   FieldDefinition,
   KeyedObject,
@@ -46,4 +48,34 @@ export type Metadata = {
 export type DocumentInternationalizationMenuProps = {
   schemaType: ObjectSchemaType
   documentId: string
+}
+
+// Extend Sanity schema definitions
+export interface DocumentInternationalizationSchemaOpts {
+  documentInternationalization?: {
+    /** Set to true to disable duplication of this field or type */
+    exclude?: boolean
+  }
+}
+
+declare module 'sanity' {
+  interface ArrayOptions extends DocumentInternationalizationSchemaOpts {}
+  interface BlockOptions extends DocumentInternationalizationSchemaOpts {}
+  interface BooleanOptions extends DocumentInternationalizationSchemaOpts {}
+  interface CrossDatasetReferenceOptions
+    extends DocumentInternationalizationSchemaOpts {}
+  interface DateOptions extends DocumentInternationalizationSchemaOpts {}
+  interface DatetimeOptions extends DocumentInternationalizationSchemaOpts {}
+  interface FileOptions extends DocumentInternationalizationSchemaOpts {}
+  interface GeopointOptions extends DocumentInternationalizationSchemaOpts {}
+  interface ImageOptions extends DocumentInternationalizationSchemaOpts {}
+  interface NumberOptions extends DocumentInternationalizationSchemaOpts {}
+  interface ObjectOptions extends DocumentInternationalizationSchemaOpts {}
+  interface ReferenceBaseOptions
+    extends DocumentInternationalizationSchemaOpts {}
+  interface SlugOptions extends DocumentInternationalizationSchemaOpts {}
+  interface StringOptions extends DocumentInternationalizationSchemaOpts {}
+  interface TextOptions extends DocumentInternationalizationSchemaOpts {}
+  interface UrlOptions extends DocumentInternationalizationSchemaOpts {}
+  interface EmailOptions extends DocumentInternationalizationSchemaOpts {}
 }

--- a/src/utils/excludePaths.ts
+++ b/src/utils/excludePaths.ts
@@ -1,0 +1,123 @@
+import {extractWithPath, Mutation} from '@sanity/mutator'
+import {
+  isDocumentSchemaType,
+  ObjectSchemaType,
+  Path,
+  pathToString,
+  SanityDocument,
+  SchemaType,
+} from 'sanity'
+
+export interface DocumentMember {
+  schemaType: SchemaType
+  path: Path
+  name: string
+  value: unknown
+}
+
+export function removeExcludedPaths(
+  doc: SanityDocument | null,
+  schemaType: ObjectSchemaType
+): SanityDocument | null {
+  // If the supplied doc is null or the schemaType
+  // isn't a document, return as is.
+  if (!isDocumentSchemaType(schemaType) || !doc) {
+    return doc
+  }
+
+  // The extractPaths function gets all the fields in the doc with
+  // a value, along with their schemaTypes and paths. We'll end up
+  // with an array of paths in string form which we want to exclude
+  const pathsToExclude: string[] = extractPaths(doc, schemaType, [])
+    // We filter for any fields which should be excluded from the document
+    // duplicate action, based on the schemaType option being set.
+    .filter(
+      (field) =>
+        field.schemaType?.options?.documentInternationalization?.exclude ===
+        true
+    )
+    // then we return the stringified version of the path
+    .map((field) => {
+      return pathToString(field.path)
+    })
+
+  // Now we can use the Mutation class from @sanity/mutator to patch the document
+  // to remove all the paths that are for one of the excluded fields. This is just
+  // done locally, and the documents themselves are not patched in the Content Lake.
+  const mut = new Mutation({
+    mutations: [
+      {
+        patch: {
+          id: doc._id,
+          unset: pathsToExclude,
+        },
+      },
+    ],
+  })
+
+  return mut.apply(doc) as SanityDocument
+}
+
+function extractPaths(
+  doc: SanityDocument,
+  schemaType: ObjectSchemaType,
+  path: Path
+): DocumentMember[] {
+  return schemaType.fields.reduce<DocumentMember[]>((acc, field) => {
+    const fieldPath = [...path, field.name]
+    const fieldSchema = field.type
+    const {value} = extractWithPath(pathToString(fieldPath), doc)[0] ?? {}
+    if (!value) {
+      return acc
+    }
+
+    const thisFieldWithPath: DocumentMember = {
+      path: fieldPath,
+      name: field.name,
+      schemaType: fieldSchema,
+      value,
+    }
+
+    if (fieldSchema.jsonType === 'object') {
+      const innerFields = extractPaths(doc, fieldSchema, fieldPath)
+
+      return [...acc, thisFieldWithPath, ...innerFields]
+    } else if (
+      fieldSchema.jsonType === 'array' &&
+      fieldSchema.of.length &&
+      fieldSchema.of.some((item) => 'fields' in item)
+    ) {
+      const {value: arrayValue} =
+        extractWithPath(pathToString(fieldPath), doc)[0] ?? {}
+
+      let arrayPaths: DocumentMember[] = []
+      if ((arrayValue as any)?.length) {
+        for (const item of arrayValue as any[]) {
+          const itemPath = [...fieldPath, {_key: item._key}]
+          let itemSchema = fieldSchema.of.find((t) => t.name === item._type)
+          if (!item._type) {
+            itemSchema = fieldSchema.of[0]
+          }
+          if (item._key && itemSchema) {
+            const innerFields = extractPaths(
+              doc,
+              itemSchema as ObjectSchemaType,
+              itemPath
+            )
+            const arrayMember = {
+              path: itemPath,
+              name: item._key,
+              schemaType: itemSchema,
+              value: item,
+            }
+            arrayPaths = [...arrayPaths, arrayMember, ...innerFields]
+          }
+        }
+      }
+
+      return [...acc, thisFieldWithPath, ...arrayPaths]
+    }
+
+    return [...acc, thisFieldWithPath]
+  }, [])
+}


### PR DESCRIPTION
This PR adds the ability to exclude certain fields when a document is duplicated. It takes the current doc and it's schema definition to find which field paths should be removed, before doing just that.