### PR TITLE
feat: allow nested languageField on documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/ui": "^1.2.2",
         "@sanity/uuid": "^3.0.2",
+        "just-safe-get": "^4.2.0",
         "sanity-plugin-internationalized-array": "^1.10.3",
         "sanity-plugin-utils": "^1.6.2"
       },
@@ -10960,6 +10961,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/just-safe-get": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/just-safe-get/-/just-safe-get-4.2.0.tgz",
+      "integrity": "sha512-+tS4Bvgr/FnmYxOGbwziJ8I2BFk+cP1gQHm6rm7zo61w1SbxBwWGEq/Ryy9Gb6bvnloPq6pz7Bmm4a0rjTNlXA=="
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/ui": "^1.2.2",
     "@sanity/uuid": "^3.0.2",
+    "just-safe-get": "^4.2.0",
     "sanity-plugin-internationalized-array": "^1.10.3",
     "sanity-plugin-utils": "^1.6.2"
   },

--- a/src/actions/DeleteTranslationAction.tsx
+++ b/src/actions/DeleteTranslationAction.tsx
@@ -1,5 +1,6 @@
 import {TrashIcon} from '@sanity/icons'
 import {ButtonTone, useToast} from '@sanity/ui'
+import get from 'just-safe-get'
 import {useCallback, useState} from 'react'
 import {DocumentActionComponent, SanityDocument, useClient} from 'sanity'
 
@@ -16,7 +17,7 @@ export const DeleteTranslationAction: DocumentActionComponent = (props) => {
   const [isDialogOpen, setDialogOpen] = useState(false)
   const [translations, setTranslations] = useState<SanityDocument[]>([])
   const onClose = useCallback(() => setDialogOpen(false), [])
-  const documentLanguage = doc ? doc[languageField] : null
+  const documentLanguage = doc ? get(doc, languageField) : null
 
   const toast = useToast()
   const client = useClient({apiVersion: API_VERSION})

--- a/src/badges/index.tsx
+++ b/src/badges/index.tsx
@@ -1,3 +1,4 @@
+import get from 'just-safe-get'
 import {DocumentBadgeDescription, DocumentBadgeProps} from 'sanity'
 
 import {useDocumentInternationalizationContext} from '../components/DocumentInternationalizationContext'
@@ -8,7 +9,7 @@ export function LanguageBadge(
   const source = props?.draft || props?.published
   const {languageField, supportedLanguages} =
     useDocumentInternationalizationContext()
-  const languageId = source?.[languageField]
+  const languageId = source ? get(source, languageField) : null
 
   if (!languageId) {
     return null

--- a/src/components/DocumentInternationalizationMenu.tsx
+++ b/src/components/DocumentInternationalizationMenu.tsx
@@ -10,6 +10,7 @@ import {
   useClickOutside,
 } from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
+import get from 'just-safe-get'
 import {FormEvent, useCallback, useMemo, useState} from 'react'
 import {useEditState} from 'sanity'
 
@@ -71,7 +72,7 @@ export function DocumentInternationalizationMenu(
   const documentIsInOneMetadataDocument = useMemo(() => {
     return Array.isArray(data) && data.length <= 1
   }, [data])
-  const sourceLanguageId = source?.[languageField] as string | undefined
+  const sourceLanguageId = source ? get(source, languageField) : undefined
   const sourceLanguageIsValid = supportedLanguages.some(
     (l) => l.id === sourceLanguageId
   )


### PR DESCRIPTION
Currently objects like `options.language` or `pageOptions.language` is unabled to use changing the default field for `languageField`.

On this PR we are using [just-safe-get](https://www.npmjs.com/package/just-safe-get) library, to Get the value at property level. This way we solve fields like: 
"`abc[0].language"` 
``"a.abc.language"`
"cde.abc.b.language"

feel free to share your opinion about it.
