### PR TITLE
Fix dup refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "react-router-dom": "^5.0.0",
     "rxjs": "^7.0.0",
     "sanity": "^3.0.0",
-    "styled-components": "^5.0.0"
+    "styled-components": "^5.2 || ^6"
   },
   "engines": {
     "node": ">=14"

--- a/src/actions/DuplicateWithi18nAction.tsx
+++ b/src/actions/DuplicateWithi18nAction.tsx
@@ -90,7 +90,7 @@ export function createDuplicateAction(pluginConfig: Ti18nConfig): DocumentAction
           const newId = buildDocId(config, dupeId, getLanguageFromDocument(t, config))
           transaction.create({
             ...t,
-            [config.fieldNames.baseReference]: dupeId,
+            [config.fieldNames.baseReference]: {_ref: dupeId, _type: 'reference', _key: uuid()},
             _id: isDraft ? `drafts.${newId}` : newId,
           })
         })

--- a/src/actions/DuplicateWithi18nAction.tsx
+++ b/src/actions/DuplicateWithi18nAction.tsx
@@ -3,8 +3,14 @@ import {CopyIcon} from '@sanity/icons'
 import {useDocumentOperation} from 'sanity'
 import {useToast} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
-import type {DocumentActionComponent, DocumentActionDescription} from 'sanity'
+import type {
+  DocumentActionComponent,
+  DocumentActionDescription,
+  Reference,
+  SanityDocument,
+} from 'sanity'
 import {
+  ApplyConfigResult,
   buildDocId,
   getBaseIdFromId,
   getLanguageFromDocument,
@@ -21,6 +27,27 @@ import {useConfig} from '../hooks'
 
 const DISABLED_REASON_TITLE = {
   NOTHING_TO_DUPLICATE: "This document doesn't yet exist so there's nothing to duplicate",
+}
+
+function buildDupeDocument(
+  base: SanityDocument,
+  config: ApplyConfigResult,
+  dupeId: string,
+  type: string
+): SanityDocument {
+  const referencesField = config.fieldNames.references
+  const baseReferences = base[referencesField] as Reference[]
+  const dupeReferences = baseReferences.map((ref) => ({
+    ...ref,
+    _ref: buildDocId(config, dupeId, ref._key),
+  }))
+
+  return {
+    ...base,
+    [referencesField]: dupeReferences,
+    _id: dupeId,
+    _type: type,
+  }
 }
 
 export function createDuplicateAction(pluginConfig: Ti18nConfig): DocumentActionComponent {
@@ -43,16 +70,27 @@ export function createDuplicateAction(pluginConfig: Ti18nConfig): DocumentAction
         const dupeId = uuid()
         const translations = await getTranslationsFor(client, config, baseDocumentId)
         const transaction = client.transaction()
-        transaction.create({
-          ...(draft ?? published),
-          _id: dupeId,
-          _type: type,
-        })
+        const baseDoc = draft ?? published
+        if (!baseDoc) throw new Error('no base doc defined')
+
+        transaction.create(
+          buildDupeDocument(
+            {
+              ...baseDoc,
+              _id: dupeId,
+              _type: type,
+            },
+            config,
+            dupeId,
+            type
+          )
+        )
         translations.forEach((t) => {
           const isDraft = t._id.startsWith('drafts.')
           const newId = buildDocId(config, dupeId, getLanguageFromDocument(t, config))
           transaction.create({
             ...t,
+            [config.fieldNames.baseReference]: dupeId,
             _id: isDraft ? `drafts.${newId}` : newId,
           })
         })


### PR DESCRIPTION
Fixes EDX-1252.

Resolves issues where duplicating with translations resulted in original document refs being mapped into the duplicated i18n map