### PR TITLE
chore: replace deprecated createConfig with defineConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ The only required configuration is:
 ```ts
 // sanity.config.ts
 
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {documentInternationalization} from '@sanity/document-internationalization'
 
-export const createConfig({
+export const defineConfig({
   // ... all other config
   plugins: [
     // ... all other plugins
@@ -102,10 +102,10 @@ The plugin also supports asynchronously retrieving languages from the dataset, m
 ```ts
 // sanity.config.ts
 
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {documentInternationalization} from '@sanity/document-internationalization'
 
-export const createConfig({
+export const defineConfig({
   // ... all other config
   plugins: [
     // ... all other plugins


### PR DESCRIPTION
The readme was still referring to the [deprecated createConfig](https://github.com/sanity-io/sanity/blob/6c1febcdd9baf45e53345b7c8d53caf37c4150d1/packages/sanity/src/core/config/defineConfig.ts#L11).