### PR TITLE
feat: adds callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ export const defineConfig({
       // Enable "manage translations" button without creating a translated version. Helpful if you have
       // pre-existing documents that you need to tie together through the metadata document
       allowCreateMetaDoc: true // defaults to false
+
+      // Optional
+      // Callback function that runs after a translation document has been created
+      callback: ({...args}) => {} // defaults to null
     })
   ]
 })

--- a/README.md
+++ b/README.md
@@ -128,21 +128,21 @@ export const defineConfig({
 
       // Optional
       // Customizes the name of the language field
-      languageField: `language` // defauts to "language"
+      languageField: `language`, // defauts to "language"
 
       // Optional
       // Keep translation.metadata references weak
-      weakReferences: true // defaults to false
+      weakReferences: true, // defaults to false
 
       // Optional
       // Adds UI for publishing all translations at once. Requires access to the Scheduling API
       // https://www.sanity.io/docs/scheduling-api
-      bulkPublish: true // defaults to false
+      bulkPublish: true, // defaults to false
 
       // Optional
       // Adds additional fields to the metadata document
       metadataFields: [
-        defineField({ name: 'slug', type: 'slug' })
+        defineField({ name: 'slug', type: 'slug' }),
       ],
 
       // Optional
@@ -153,11 +153,21 @@ export const defineConfig({
       // Optional
       // Enable "manage translations" button without creating a translated version. Helpful if you have
       // pre-existing documents that you need to tie together through the metadata document
-      allowCreateMetaDoc: true // defaults to false
+      allowCreateMetaDoc: true, // defaults to false
 
       // Optional
       // Callback function that runs after a translation document has been created
-      callback: ({...args}) => {} // defaults to null
+      // Note: Defaults to null
+      callback: ({
+        sourceDocument, // The document in the original language
+        newDocument, // The newly created translation of the source document
+        sourceLanguageId, // The id of the original language
+        destinationLanguageId, // The id of the destination language
+        metaDocumentId, // The id of the meta document referencing the document translations
+        client // Sanity client
+      }) {
+        // Your function implementation
+      }
     })
   ]
 })

--- a/src/components/LanguageOption.tsx
+++ b/src/components/LanguageOption.tsx
@@ -58,7 +58,7 @@ export default function LanguageOption(props: LanguageOptionProps) {
     .length
     ? metadata.translations.find((t) => t._key === language.id)
     : undefined
-  const {apiVersion, languageField, weakReferences} =
+  const {apiVersion, languageField, weakReferences, callback} =
     useDocumentInternationalizationContext()
   const client = useClient({apiVersion})
   const toast = useToast()
@@ -146,6 +146,8 @@ export default function LanguageOption(props: LanguageOptionProps) {
       .then(() => {
         const metadataExisted = Boolean(metadata?._createdAt)
 
+        callback?.(newTranslationDocument, client)
+
         return toast.push({
           status: 'success',
           title: `Created "${language.title}" translation`,
@@ -179,6 +181,7 @@ export default function LanguageOption(props: LanguageOptionProps) {
     sourceLanguageId,
     toast,
     weakReferences,
+    callback,
   ])
 
   let message

--- a/src/components/LanguageOption.tsx
+++ b/src/components/LanguageOption.tsx
@@ -146,8 +146,22 @@ export default function LanguageOption(props: LanguageOptionProps) {
       .then(() => {
         const metadataExisted = Boolean(metadata?._createdAt)
 
-        callback?.(newTranslationDocument, newMetadataDocument, client)
-
+        try {
+          callback?.({
+            newTranslationDocument,
+            client,
+            metadataId,
+            sourceLanguageId, 
+            destinationLanguageId: language.id
+          })
+        } catch (err) {
+          toast.push({
+            status: 'error',
+            title: `Callback`,
+            description: `Error while running callback - ${err}.`,
+          })
+        }
+        
         return toast.push({
           status: 'success',
           title: `Created "${language.title}" translation`,

--- a/src/components/LanguageOption.tsx
+++ b/src/components/LanguageOption.tsx
@@ -15,7 +15,12 @@ import {type ObjectSchemaType, type SanityDocument, useClient} from 'sanity'
 
 import {METADATA_SCHEMA_NAME} from '../constants'
 import {useOpenInNewPane} from '../hooks/useOpenInNewPane'
-import type {Language, Metadata, MetadataDocument, TranslationReference} from '../types'
+import type {
+  Language,
+  Metadata,
+  MetadataDocument,
+  TranslationReference,
+} from '../types'
 import {createReference} from '../utils/createReference'
 import {removeExcludedPaths} from '../utils/excludePaths'
 import {useDocumentInternationalizationContext} from './DocumentInternationalizationContext'
@@ -146,22 +151,21 @@ export default function LanguageOption(props: LanguageOptionProps) {
       .then(() => {
         const metadataExisted = Boolean(metadata?._createdAt)
 
-        try {
-          callback?.({
-            newTranslationDocument,
-            client,
-            metadataId,
-            sourceLanguageId, 
-            destinationLanguageId: language.id
-          })
-        } catch (err) {
+        callback?.({
+          client,
+          sourceLanguageId,
+          sourceDocument: source,
+          newDocument: newTranslationDocument,
+          destinationLanguageId: language.id,
+          metaDocumentId: metadataId,
+        }).catch((err) => {
           toast.push({
             status: 'error',
             title: `Callback`,
             description: `Error while running callback - ${err}.`,
           })
-        }
-        
+        })
+
         return toast.push({
           status: 'success',
           title: `Created "${language.title}" translation`,

--- a/src/components/LanguageOption.tsx
+++ b/src/components/LanguageOption.tsx
@@ -15,7 +15,7 @@ import {type ObjectSchemaType, type SanityDocument, useClient} from 'sanity'
 
 import {METADATA_SCHEMA_NAME} from '../constants'
 import {useOpenInNewPane} from '../hooks/useOpenInNewPane'
-import type {Language, Metadata, TranslationReference} from '../types'
+import type {Language, Metadata, MetadataDocument, TranslationReference} from '../types'
 import {createReference} from '../utils/createReference'
 import {removeExcludedPaths} from '../utils/excludePaths'
 import {useDocumentInternationalizationContext} from './DocumentInternationalizationContext'
@@ -121,7 +121,7 @@ export default function LanguageOption(props: LanguageOptionProps) {
       schemaType.name,
       !weakReferences
     )
-    const newMetadataDocument = {
+    const newMetadataDocument: MetadataDocument = {
       _id: metadataId,
       _type: METADATA_SCHEMA_NAME,
       schemaTypes: [schemaType.name],
@@ -146,7 +146,7 @@ export default function LanguageOption(props: LanguageOptionProps) {
       .then(() => {
         const metadataExisted = Boolean(metadata?._createdAt)
 
-        callback?.(newTranslationDocument, client)
+        callback?.(newTranslationDocument, newMetadataDocument, client)
 
         return toast.push({
           status: 'success',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,4 +12,5 @@ export const DEFAULT_CONFIG: PluginConfigContext = {
   metadataFields: [],
   apiVersion: API_VERSION,
   allowCreateMetaDoc: false,
+  callback: null,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import type {
   Reference,
   SanityClient,
   SanityDocument,
-  SanityDocumentLike
+  SanityDocumentLike,
 } from 'sanity'
 
 export type Language = {
@@ -20,11 +20,12 @@ export type SupportedLanguages =
   | ((client: SanityClient) => Promise<Language[]>)
 
 export type PluginCallbackArgs = {
-  newTranslationDocument: SanityDocument
-  client: SanityClient
-  metadataId: string
+  sourceDocument: SanityDocument
+  newDocument: SanityDocument
   sourceLanguageId: string
   destinationLanguageId: string
+  metaDocumentId: string
+  client: SanityClient
 }
 
 export type PluginConfig = {
@@ -36,9 +37,7 @@ export type PluginConfig = {
   metadataFields?: FieldDefinition[]
   apiVersion?: string
   allowCreateMetaDoc?: boolean
-  callback?:
-    | ((args: PluginCallbackArgs) => Promise<void>)
-    | null
+  callback?: ((args: PluginCallbackArgs) => Promise<void>) | null
 }
 
 // Context version of config

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import type {
   Reference,
   SanityClient,
   SanityDocument,
+  SanityDocumentLike
 } from 'sanity'
 
 export type Language = {
@@ -18,6 +19,14 @@ export type SupportedLanguages =
   | Language[]
   | ((client: SanityClient) => Promise<Language[]>)
 
+export type PluginCallbackArgs = {
+  newTranslationDocument: SanityDocument
+  client: SanityClient
+  metadataId: string
+  sourceLanguageId: string
+  destinationLanguageId: string
+}
+
 export type PluginConfig = {
   supportedLanguages: SupportedLanguages
   schemaTypes: string[]
@@ -28,7 +37,7 @@ export type PluginConfig = {
   apiVersion?: string
   allowCreateMetaDoc?: boolean
   callback?:
-    | ((document: SanityDocument, metadataDocument: MetadataDocument, client: SanityClient) => Promise<void>)
+    | ((args: PluginCallbackArgs) => Promise<void>)
     | null
 }
 
@@ -50,7 +59,7 @@ export type Metadata = {
   translations: TranslationReference[]
 }
 
-export type MetadataDocument = SanityDocument & {
+export type MetadataDocument = SanityDocumentLike & {
   schemaTypes: string[]
   translations: TranslationReference[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export type PluginConfig = {
   apiVersion?: string
   allowCreateMetaDoc?: boolean
   callback?:
-    | ((document: SanityDocument, client: SanityClient) => Promise<void>)
+    | ((document: SanityDocument, metadataDocument: MetadataDocument, client: SanityClient) => Promise<void>)
     | null
 }
 
@@ -47,6 +47,11 @@ export type TranslationReference = KeyedObject & {
 export type Metadata = {
   _id: string
   _createdAt: string
+  translations: TranslationReference[]
+}
+
+export type MetadataDocument = SanityDocument & {
+  schemaTypes: string[]
   translations: TranslationReference[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import type {
   ObjectSchemaType,
   Reference,
   SanityClient,
+  SanityDocument,
 } from 'sanity'
 
 export type Language = {
@@ -26,6 +27,9 @@ export type PluginConfig = {
   metadataFields?: FieldDefinition[]
   apiVersion?: string
   allowCreateMetaDoc?: boolean
+  callback?:
+    | ((document: SanityDocument, client: SanityClient) => Promise<void>)
+    | null
 }
 
 // Context version of config


### PR DESCRIPTION
Adds the option of providing a callback function to carry out side-effects after a translation document has been created by the plugin.

In my view this would fulfill a similar role to that of custom actions which are available when manually publishing/updating etc.